### PR TITLE
PHPhotoLibrary 사용하기 #6

### DIFF
--- a/PhotosApp/PhotosApp/Controller/ViewController.swift
+++ b/PhotosApp/PhotosApp/Controller/ViewController.swift
@@ -13,11 +13,14 @@ class ViewController: UIViewController {
     
     @IBOutlet weak var collectionView: UICollectionView!
     private let datasource = CollectionViewDataSource()
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.dataSource = datasource
         authorizationStatus()
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(reloadAsset(_:)),
+                                               name: Notification.Name.needToAssetReload,
+                                               object: nil)
     }
     
     func authorizationStatus() {
@@ -43,6 +46,28 @@ class ViewController: UIViewController {
             
         default:
             fatalError("권한 없음")
+        }
+    }
+    
+    @objc func reloadAsset(_ notification: Notification) {
+        if let userInfo = notification.userInfo {
+            DispatchQueue.main.async {
+                self.collectionView.performBatchUpdates({
+                    if userInfo["removed"] != nil {
+                        guard let removed = userInfo["removed"] as? IndexSet else {return}
+                        self.collectionView.deleteItems(at: removed.map { IndexPath(item: $0, section:0) })
+                    }
+                    
+                    if userInfo["inserted"] != nil{
+                        guard let inserted = userInfo["inserted"] as? IndexSet else {return}
+                        self.collectionView.insertItems(at: inserted.map { IndexPath(item: $0, section:0) })
+                    }
+                    if userInfo["changed"] != nil {
+                        guard let changed = userInfo["changed"] as? IndexSet else {return}
+                        self.collectionView.reloadItems(at: changed.map { IndexPath(item: $0, section:0) })
+                    }
+                })
+            }
         }
     }
 }

--- a/PhotosApp/PhotosApp/Model/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Model/CollectionViewDataSource.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class CollectionViewDataSource: NSObject {
     
-    let photoManager = PhotoManager()
+    private let photoManager = PhotoManager()
     
     public func reloadAsset() {
         photoManager.reloadAsset()

--- a/PhotosApp/PhotosApp/Model/CollectionViewDataSource.swift
+++ b/PhotosApp/PhotosApp/Model/CollectionViewDataSource.swift
@@ -29,7 +29,7 @@ extension CollectionViewDataSource: UICollectionViewDataSource {
             ) as? PhotoCell else { return UICollectionViewCell() }
         let collectionViewIndexPathItem: Int = collectionView.indexPathForItem(at: CGPoint(x: cell.frame.origin.x, y: cell.frame.origin.y))?.item ?? 0
         if collectionViewIndexPathItem == indexPath.item {
-            photoManager.load(index: indexPath.item, size: cell.frame.size, cell: cell)
+            cell.apply(with: photoManager.load(index: indexPath.item, size: cell.frame.size) as? UIImage)
         }
         return cell
     }

--- a/PhotosApp/PhotosApp/Model/PhotoManager.swift
+++ b/PhotosApp/PhotosApp/Model/PhotoManager.swift
@@ -26,10 +26,6 @@ class PhotoManager: NSObject {
         PHPhotoLibrary.shared().register(self)
     }
     
-    func getAsset() -> PHFetchResult<PHAsset>{
-        return fetchResult
-    }
-    
     public func load(index: Int, size: CGSize, cell: PhotoCell) {
         manager.requestImage(
             for: fetchResult[index],

--- a/PhotosApp/PhotosApp/Model/PhotoManager.swift
+++ b/PhotosApp/PhotosApp/Model/PhotoManager.swift
@@ -26,15 +26,19 @@ class PhotoManager: NSObject {
         PHPhotoLibrary.shared().register(self)
     }
     
-    public func load(index: Int, size: CGSize, cell: PhotoCell) {
+    public func load(index: Int, size: CGSize) -> AnyObject? {
+        var image: AnyObject?
+        
         manager.requestImage(
             for: fetchResult[index],
             targetSize: size,
             contentMode: .aspectFill,
             options: .none
-        ) { image, _ in
-            cell.apply(with: image)
+        ) { photo, _ in
+            image = photo
         }
+        
+        return image
     }
     
     public func reloadAsset() {


### PR DESCRIPTION
asset의 변화를 감지하기 위해서 PHPhotoLibraryChangeObserver을 채택했습니다.
원래 PHPhotoLibraryChangeObserver를 채택하는 클래스는 ViewController였고, 동작을 PhotoManger에 보내서 asset에 접근하는 방식을 사용했습니다. collectionView를 업데이트 해야하기 때문에 UICollectionView 프로퍼티가 있는 클래스에서 처리를 했습니다. 그러나 페어와 커뮤니케이션 결과 private 프로퍼티를 게터로 넘기는 형식을 사용한 것이 적합하지 않다고 생각이 되었습니다.
따라서 PhotoManger 클래스에서 PHPhotoLibraryChangeObserver를 채택하게 하였고, 결과를 Notification해줬습니다. 이를 ViewController에서 관찰하고 있다가, 처리해주는 방식을 채택했습니다.